### PR TITLE
Add +official flag for ranklist (#22)

### DIFF
--- a/tle/util/cache_system2.py
+++ b/tle/util/cache_system2.py
@@ -583,11 +583,11 @@ class RanklistCache:
         for contest_id, ranklist in ranklist_by_contest.items():
             self.ranklist_by_contest[contest_id] = ranklist
 
-    async def generate_ranklist(self, contest_id, *, fetch_changes=False, predict_changes=False):
+    async def generate_ranklist(self, contest_id, *, fetch_changes=False, predict_changes=False, show_unofficial=True):
         assert fetch_changes ^ predict_changes
 
         contest, problems, standings = await cf.contest.standings(contest_id=contest_id,
-                                                                  show_unofficial=True)
+                                                                  show_unofficial=show_unofficial)
         now = time.time()
 
         # Exclude PRACTICE and MANAGER

--- a/tle/util/handledict.py
+++ b/tle/util/handledict.py
@@ -2,13 +2,14 @@
     A case insensitive dictionay with bare minimum functions required for handling usernames.
 """
 
+
 class HandleDict:
     def __init__(self):
         self._store = {}
 
     @staticmethod
     def _getlower(key):
-        return key.lower() if type(key)==str else key
+        return key.lower() if type(key) == str else key
 
     def __setitem__(self, key, value):
         # Use the lowercased key for lookups, but store the actual
@@ -17,6 +18,13 @@ class HandleDict:
 
     def __getitem__(self, key):
         return self._store[self._getlower(key)][1]
+
+    # get correct handle irrespective of the input case of the handle (if the handle is present)
+    def get_correct_handle(self, key):
+        try:
+            return self._store[self._getlower(key)][0]
+        except KeyError:
+            return ""
 
     def __delitem__(self, key):
         del self._store[self._getlower(key)]

--- a/tle/util/ranklist/ranklist.py
+++ b/tle/util/ranklist/ranklist.py
@@ -38,11 +38,7 @@ class Ranklist:
 
         self.standing_by_id = HandleDict()
         for row in self.standings:
-            if row.party.ghost:
-                # Apparently ghosts don't have team ID.
-                id_ = row.party.teamName
-            else:
-                id_ = row.party.teamId or row.party.members[0].handle
+            id_ = row.party.teamName or row.party.members[0].handle
             self.standing_by_id[id_] = row
 
         self.delta_by_handle = None


### PR DESCRIPTION
* Add +official flag for ranklist Now the ranklist can support showing only official contestants (eg : contestants rated < 2100 in a div2)

* Handling Edu ranklist

* Fix same (points,penalty) pair getting different ranks

* Corrections/Refactor for PR comments

* PR Comments Fix and handling lowercase input
1. Add official filtering only for Educational Contest
2. Fix the support for case insensitive handle input when using +official flag